### PR TITLE
Update for OmniAuth 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,6 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # required gems for xero-ruby-oauth2 demo app
-gem 'omniauth-xero-oauth2', :path => '../xero-oauth2-omniauth-strategy' # as a local gem
-# gem 'omniauth-xero-oauth2', '>= 0.9.3'
+# gem 'omniauth-xero-oauth2', :path => '../xero-oauth2-omniauth-strategy' # as a local gem
+gem 'omniauth-xero-oauth2', '~> 1.0.2'
 gem 'faraday' #for making http calls

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-PATH
-  remote: ../xero-oauth2-omniauth-strategy
-  specs:
-    omniauth-xero-oauth2 (1.0.1)
-      omniauth (~> 1.9.1)
-      omniauth-oauth2 (~> 1.7.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -118,7 +111,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.9.0)
+    loofah (2.9.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -133,8 +126,10 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.7)
-    nokogiri (1.11.2)
+    nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    nokogiri (1.11.3-x86_64-darwin)
       racc (~> 1.4)
     oauth2 (1.4.7)
       faraday (>= 0.8, < 2.0)
@@ -142,16 +137,22 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.9.1)
+    omniauth (2.0.4)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
+      rack-protection
     omniauth-oauth2 (1.7.1)
       oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
+    omniauth-xero-oauth2 (1.0.2)
+      omniauth (~> 2.0.0)
+      omniauth-oauth2 (~> 1.7.1)
     public_suffix (4.0.6)
     puma (3.12.6)
     racc (1.5.2)
     rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.3.1)
@@ -237,6 +238,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-19
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
@@ -247,7 +249,7 @@ DEPENDENCIES
   faraday
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
-  omniauth-xero-oauth2!
+  omniauth-xero-oauth2 (~> 1.0.2)
   puma (~> 3.11)
   rails (>= 6.0.2.2)
   sass-rails (~> 5.0)

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -10,5 +10,22 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   )
 end
 
+# Since Omniauth 2.0.0, we need the following token verfication process
+class TokenVerifier
+  include ActiveSupport::Configurable
+  include ActionController::RequestForgeryProtection
+
+  def call(env)
+    @request = ActionDispatch::Request.new(env.dup)
+    raise OmniAuth::AuthenticityError unless verified_request?
+  end
+
+  private
+  attr_reader :request
+  delegate :params, :session, to: :request
+end
+
+OmniAuth.config.request_validation_phase = TokenVerifier.new
+
 # by default the callback url / redirect_uri on developer.xero.com should be seet to /auth/xero_oauth2/callback
 # to override it, added redirect_uri: 'https:/your.app/callback/url' to provider() function 


### PR DESCRIPTION
Included a Token Verifier process as required from OmniAuth 2.0.0+

Gemfile updated to include v1.0.2 of the Xero OAuth 2.0 strategy gem